### PR TITLE
+soinside.com, translate "[duplicate]"

### DIFF
--- a/back2source.user.js
+++ b/back2source.user.js
@@ -110,6 +110,7 @@
 // @match        *://*.rudata.ru/wiki/*
 // @match        *://*.sbup.com/wiki/*
 // @match        *://*.savepearlharbor.com/?p=*
+// @match        *://*.soinside.com/question/*
 // @match        *://*.sprosi.pro/questions/*
 // @match        *://*.stackanswers.net/questions/*
 // @match        *://*.stackoom.com/question/*
@@ -301,7 +302,7 @@ a{
                     anonymous: true,
                     onload: (xhr) => {
                         if (xhr.status === 200) {
-                            resolve(xhr.response.text)
+                            resolve(xhr.response.text.replace(/ *\[repeat\]/i," [duplicate]"))
                         } else {
                             reject(xhr)
                         }


### PR DESCRIPTION
+soinside.com
Yandex translates " [duplicate]" the most times to "[Repeat]", sometimes even without leading space. If we search for " [duplicate]" instead, the results are much better.
Examples: http://www.soinside.com/question/AKcb4XEvHatr4MdAZM9R99, http://www.soinside.com/question/uzmDWFW6xDmNLgN3obxzPP, http://www.soinside.com/question/2oCTWqwDXec67Utq3Awcb9 I don't know if the replacement of the translation could be on a better place, if so feel free to change it.